### PR TITLE
Add persistent player block list with UI

### DIFF
--- a/client/main/css/main.scss
+++ b/client/main/css/main.scss
@@ -455,3 +455,28 @@ span.username {
     box-shadow: 0px 0px 2px 0px rgba(50, 50, 50, 1);
   }
 }
+
+/* Added or updated by Jam  */
+#options-flex-layout {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+}
+
+#options-original {
+  flex: 1 1 220px;
+}
+
+#options-blocklist {
+    flex: 1 1 175px;
+    max-width: 340px;
+    height: 195px;
+}
+
+#option-block-list {
+    width: 100%;
+    min-width: 175px;
+    max-width: 340px;
+    height: clamp(104px, calc(100% - 1em - 28px), 123px);
+    box-sizing: border-box;
+}

--- a/client/main/index.html
+++ b/client/main/index.html
@@ -317,56 +317,68 @@
       <div id="lobby-games"></div>
     </div>
     <div id="options">
-      <div class="header">Options</div>
-      <div>
-        <input id="option-enable-page-title-notifications" type="checkbox" />
-        <label for="option-enable-page-title-notifications">Enable page title notifications</label>
-      </div>
-      <div>
-        Sound:
-        <select id="option-sound">
-          <option value="beep">Beep</option>
-          <option value="cha-ching">Cha-Ching</option>
-        </select>
-      </div>
-      <div>
-        Volume:
-        <select id="option-volume">
-          <option value="100">100%</option>
-          <option value="90">90%</option>
-          <option value="80">80%</option>
-          <option value="70">70%</option>
-          <option value="60">60%</option>
-          <option value="50">50%</option>
-          <option value="40">40%</option>
-          <option value="30">30%</option>
-          <option value="20">20%</option>
-          <option value="10">10%</option>
-          <option value="0">0%</option>
-        </select>
-      </div>
-      <div>
-        <input id="option-enable-high-contrast-colors" type="checkbox" />
-        <label for="option-enable-high-contrast-colors">Enable high contrast colors</label>
-      </div>
-      <div>
-        <input id="option-enable-text-background-colors" type="checkbox" />
-        <label for="option-enable-text-background-colors">Enable text background colors</label>
-      </div>
-      <div>
-        Color scheme:
-        <select id="option-color-scheme">
-          <option value="netacquire">NetAcquire</option>
-          <option value="white">White</option>
-        </select>
-      </div>
-      <div>
-        Game board label mode:
-        <select id="option-game-board-label-mode">
-          <option value="nothing">Show nothing</option>
-          <option value="coordinates">Show coordinates</option>
-          <option value="hotel initials">Show hotel initials</option>
-        </select>
+      <div id="options-flex-layout"> <!-- avoids need to alter js when accomodating new layout -->
+        <div id="options-original">
+          <div class="header">Options</div>
+          <div>
+            <input id="option-enable-page-title-notifications" type="checkbox" />
+            <label for="option-enable-page-title-notifications">Enable page title notifications</label>
+          </div>
+          <div>
+            Sound:
+            <select id="option-sound">
+              <option value="beep">Beep</option>
+              <option value="cha-ching">Cha-Ching</option>
+            </select>
+          </div>
+          <div>
+            Volume:
+            <select id="option-volume">
+              <option value="100">100%</option>
+              <option value="90">90%</option>
+              <option value="80">80%</option>
+              <option value="70">70%</option>
+              <option value="60">60%</option>
+              <option value="50">50%</option>
+              <option value="40">40%</option>
+              <option value="30">30%</option>
+              <option value="20">20%</option>
+              <option value="10">10%</option>
+              <option value="0">0%</option>
+            </select>
+          </div>
+          <div>
+            <input id="option-enable-high-contrast-colors" type="checkbox" />
+            <label for="option-enable-high-contrast-colors">Enable high contrast colors</label>
+          </div>
+          <div>
+            <input id="option-enable-text-background-colors" type="checkbox" />
+            <label for="option-enable-text-background-colors">Enable text background colors</label>
+          </div>
+          <div>
+            Color scheme:
+            <select id="option-color-scheme">
+              <option value="netacquire">NetAcquire</option>
+              <option value="white">White</option>
+            </select>
+          </div>
+          <div>
+            Game board label mode:<BR>
+            <select id="option-game-board-label-mode">
+              <option value="nothing">Show nothing</option>
+              <option value="coordinates">Show coordinates</option>
+              <option value="hotel initials">Show hotel initials</option>
+            </select>
+          </div>
+        </div>
+        <div id="options-blocklist">
+          <div>Blocked players and IP addresses, one per line:</div>
+          <textarea id="option-block-list" rows="5" style="box-sizing: border-box;"></textarea>
+          <div>
+            <input id="button-save-block-list" type="button" value="Save Block List" />
+            <span id="block-list-status"></span>
+          </div>
+        </div>
       </div>
     </div>
     <div id="global-chat">

--- a/client/main/js/lobby.js
+++ b/client/main/js/lobby.js
@@ -433,6 +433,11 @@ function reset() {
   initial_loading = true;
 }
 
+function joinGameBlocked(game_id) {
+  $('#lobby-game-' + game_id + ' .button-join-game')
+    .prop('disabled', true);
+}
+
 function onInitializationComplete() {
   initializeCreateGameForm();
   $('#cg-mode').change(createGameModeChanged);
@@ -455,6 +460,7 @@ pubsub.subscribe(enums.PubSub.Server_DestroyGame, destroyGame);
 pubsub.subscribe(enums.PubSub.Network_MessageProcessingComplete, messageProcessingComplete);
 pubsub.subscribe(enums.PubSub.Network_Disconnect, reset);
 pubsub.subscribe(enums.PubSub.Client_InitializationComplete, onInitializationComplete);
+pubsub.subscribe(enums.PubSub.Server_JoinGameBlocked, joinGameBlocked);
 
 module.exports = {
   setShowOnGamePage: setShowOnGamePage,

--- a/client/main/js/options.js
+++ b/client/main/js/options.js
@@ -1,5 +1,6 @@
 var common_functions = require('./common_functions'),
   enums = require('./enums'),
+  network = require('./network'),
   pubsub = require('./pubsub'),
   current_page = null,
   show_on_game_page = false,
@@ -176,12 +177,47 @@ function processChange() {
   pubsub.publish(enums.PubSub.Client_SetOption, option_id, value);
 }
 
+var blockListInitialized = false;
+
+function setBlockList(block_list) {
+  $('#option-block-list').val(block_list);
+  $('#button-save-block-list').prop('disabled', false);
+
+  if (blockListInitialized) {
+    $('#block-list-status').text('Saved.');
+  } else {
+    $('#block-list-status').text('');
+    blockListInitialized = true;
+  }
+}
+
+
+function setBlockListError() {
+  $('#button-save-block-list').prop('disabled', false);
+  $('#block-list-status').text('Save failed.');
+}
+
+function saveBlockList() {
+  var block_list = $('#option-block-list').val();
+
+  $('#button-save-block-list').prop('disabled', true);
+  $('#block-list-status').text('Saving...');
+
+  network.sendMessage(
+    enums.CommandsToServer.SetBlockList,
+    block_list
+  );
+}
+
 function onInitializationComplete() {
   initialize();
 
-  $('#options input, #options select').change(processChange);
+  $('#options input[type="checkbox"], #options select').change(processChange);
+  $('#button-save-block-list').click(saveBlockList);
 }
 
+pubsub.subscribe(enums.PubSub.Server_SetBlockList, setBlockList);
+pubsub.subscribe(enums.PubSub.Server_SetBlockListError, setBlockListError);
 pubsub.subscribe(enums.PubSub.Client_SetPage, setPage);
 pubsub.subscribe(enums.PubSub.Client_InitializationComplete, onInitializationComplete);
 

--- a/docs/PLAYER-BLOCK-LIST.md
+++ b/docs/PLAYER-BLOCK-LIST.md
@@ -1,0 +1,43 @@
+# Player Block Lists
+
+## Purpose
+
+Prevent unwanted players and scripted game-bombing clients from joining games
+created by users who have blocked them.
+
+## User interface
+
+Each registered user has a server-side block list.
+
+The format is one entry per line:
+
+    bad-player1
+    107.77.
+    192.145.119.
+
+## Matching rules
+
+- Blank lines are ignored.
+- Leading and trailing whitespace is ignored.
+- A complete IPv4 address matches that exact address.
+- An IPv4 prefix ending with a period matches any address beginning with it.
+- All other entries are matched against usernames.
+- Username matching is case-insensitive.
+
+## Enforcement
+
+- Enforcement occurs on the Python server before accepting a new game join.
+- Hiding or disabling the Join button is secondary and is not relied upon for security.
+- Watching a game is allowed.
+- Rejoining an existing seat is allowed.
+- Updating a block list does not remove players already in a game.
+
+## Database change
+
+Migration:
+
+    migrations/001-add-user-block-list.sql
+
+Adds:
+
+    user.block_list TEXT NULL

--- a/migrations/001-add-user-block-list.sql
+++ b/migrations/001-add-user-block-list.sql
@@ -1,0 +1,2 @@
+ALTER TABLE user
+    ADD COLUMN block_list TEXT NULL AFTER password;

--- a/server/enums.py
+++ b/server/enums.py
@@ -26,6 +26,9 @@ class CommandsToClient(enum.Enum):
     AddGlobalChatMessage = 21
     AddGameChatMessage = 22
     DestroyGame = 23
+    SetBlockList = 24
+    SetBlockListError = 25
+    JoinGameBlocked = 26
 
 
 class CommandsToServer(enum.Enum):
@@ -37,7 +40,7 @@ class CommandsToServer(enum.Enum):
     DoGameAction = 5
     SendGlobalChatMessage = 6
     SendGameChatMessage = 7
-
+    SetBlockList = 8
 
 class Errors(enum.Enum):
     NotUsingLatestVersion = 0

--- a/server/orm.py
+++ b/server/orm.py
@@ -194,14 +194,20 @@ class Record(Base):
 
 class User(Base):
     __tablename__ = "user"
+
     user_id = Column(INTEGER(unsigned=True), primary_key=True, nullable=False)
     name = Column(String(32, convert_unicode="force"), nullable=False)
     password = Column(String(64, convert_unicode="force"))
-    __table_args__ = (UniqueConstraint("name"),)
+    block_list = Column(Text(convert_unicode="force"))
 
     def __repr__(self):
-        params = (repr(self.user_id), repr(self.name), repr(self.password))
-        return "User(user_id=%s, name=%s, password=%s)" % params
+        params = (
+            repr(self.user_id),
+            repr(self.name),
+            repr(self.password),
+            repr(self.block_list),
+        )
+        return "User(user_id=%s, name=%s, password=%s, block_list=%s)" % params
 
 
 class Lookup:

--- a/server/server.js
+++ b/server/server.js
@@ -41,6 +41,47 @@
     return true;
   }
 
+function normalizeBlockList(block_list) {
+  var lines,
+    normalized_lines = [],
+    seen = {},
+    i,
+    line;
+
+  if (typeof block_list !== 'string') {
+    return null;
+  }
+
+  block_list = block_list.replace(/\r\n?/g, '\n');
+
+  if (block_list.length > 4096) {
+    return null;
+  }
+
+  lines = block_list.split('\n');
+
+  for (i = 0; i < lines.length; i++) {
+    line = lines[i].trim();
+
+    if (line.length === 0) {
+      continue;
+    }
+
+    // Only allow:
+    //   A-Z a-z 0-9 space . - _
+    if (!/^[A-Za-z0-9._ -]+$/.test(line)) {
+      return null;
+    }
+
+    if (!Object.prototype.hasOwnProperty.call(seen, line)) {
+      seen[line] = true;
+      normalized_lines.push(line);
+    }
+  }
+
+  return normalized_lines.join('\n');
+}
+
   app.use(
     body_parser.urlencoded({
       extended: false,
@@ -190,6 +231,7 @@
 
   var socket_id_to_socket = {};
   var socket_id_to_client_id = {};
+  var socket_id_to_username = {};
   var client_id_to_socket = {};
 
   function handle_login(socket, version, username, password) {
@@ -210,10 +252,24 @@
       socket.close();
     };
 
-    var pass_to_python = function (replace_existing_user) {
-      console.log(socket.id, 'pass_to_python');
-      python_server.write('connect ' + JSON.stringify([username, ip_address, socket.id, replace_existing_user]) + '\n');
-    };
+var pass_to_python = function (replace_existing_user, block_list) {
+  console.log(socket.id, 'pass_to_python');
+
+  socket_id_to_username[socket.id] = username;
+
+  python_server.write(
+    'connect ' +
+      JSON.stringify([
+        username,
+        ip_address,
+        socket.id,
+        replace_existing_user,
+        block_list || '',
+      ]) +
+      '\n'
+  );
+};
+
 
     if (version !== server_version) {
       return_fatal_error(enums.Errors.NotUsingLatestVersion);
@@ -228,7 +284,7 @@
               if (password.length > 0) {
                 return_fatal_error(enums.Errors.ProvidedPassword);
               } else {
-                pass_to_python(false);
+                pass_to_python(false, results[0].block_list);
               }
             } else {
               if (password.length === 0) {
@@ -236,14 +292,14 @@
               } else if (password !== results[0].password) {
                 return_fatal_error(enums.Errors.IncorrectPassword);
               } else {
-                pass_to_python(true);
+                pass_to_python(true, results[0].block_list);
               }
             }
           } else {
             if (password.length > 0) {
               return_fatal_error(enums.Errors.ProvidedPassword);
             } else {
-              pass_to_python(false);
+              pass_to_python(false, '');
             }
           }
         } else {
@@ -289,10 +345,65 @@
 
         initializing = false;
       } else {
-        var client_id = socket_id_to_client_id[socket.id];
+        var client_id = socket_id_to_client_id[socket.id],
+          parsed_data,
+          block_list,
+          username;
 
         if (client_id) {
-          python_server.write(client_id + ' ' + data.replace(/\s+/g, ' ') + '\n');
+          try {
+            parsed_data = JSON.parse(data);
+          } catch (e) {
+            console.log(socket.id, 'invalid command JSON', JSON.stringify(e));
+            socket.close();
+            return;
+          }
+
+          if (
+            parsed_data[0] === enums.CommandsToServer.SetBlockList &&
+            parsed_data.length === 2
+          ) {
+            block_list = normalizeBlockList(parsed_data[1]);
+            username = socket_id_to_username[socket.id];
+
+            if (block_list === null || username === undefined) {
+              socket.write(
+                JSON.stringify([
+                  [enums.CommandsToClient.SetBlockListError],
+                ])
+              );
+            } else {
+              pool.query(
+                'insert into user (name, block_list) values (?, ?) ' +
+                  'on duplicate key update block_list = values(block_list)',
+                [username, block_list],
+                function (err) {
+                  if (err === null) {
+                    python_server.write(
+                      client_id +
+                        ' ' +
+                        JSON.stringify([
+                          enums.CommandsToServer.SetBlockList,
+                          block_list,
+                        ]) +
+                        '\n'
+                    );
+                  } else {
+                    console.log(socket.id, 'set block list error', err);
+                    socket.write(
+                      JSON.stringify([
+                        [enums.CommandsToClient.SetBlockListError],
+                      ])
+                    );
+                  }
+                }
+              );
+            }
+          } else {
+            python_server.write(
+              client_id + ' ' + data.replace(/\s+/g, ' ') + '\n'
+            );
+          }
         }
       }
     });

--- a/server/server.py
+++ b/server/server.py
@@ -180,10 +180,24 @@ class Server:
 
 
 class Client:
-    def __init__(self, server, username, ip_address, socket_id, replace_existing_user):
+    def __init__(
+        self,
+        server,
+        username,
+        ip_address,
+        socket_id,
+        replace_existing_user,
+        block_list,
+    ):
+
         self._server = server
         self.username = username
         self.ip_address = ip_address
+        self.block_list = ""
+        self.blocked_usernames = set()
+        self.blocked_ip_addresses = set()
+        self.blocked_ip_prefixes = set()
+        self._set_block_list(block_list)
         self.client_id = self._server.next_client_id_manager.get_id()
         self._logged_in = False
         self.game_id = None
@@ -242,6 +256,10 @@ class Client:
 
         messages_client.append(
             [enums.CommandsToClient.SetClientId.value, self.client_id]
+        )
+
+        messages_client.append(
+            [enums.CommandsToClient.SetBlockList.value, self.block_list]
         )
 
         # tell client about other clients' data
@@ -319,6 +337,56 @@ class Client:
 
         self._server.flush_pending_messages()
 
+    @staticmethod
+    def _is_ipv4_address(value):
+        parts = value.split(".")
+        return (
+            len(parts) == 4
+            and all(
+                part.isdigit()
+                and 0 <= int(part) <= 255
+                and str(int(part)) == part
+                for part in parts
+            )
+        )
+
+    @staticmethod
+    def _is_ipv4_prefix(value):
+        if not value.endswith("."):
+            return False
+
+        parts = value[:-1].split(".")
+        return (
+            1 <= len(parts) <= 3
+            and all(
+                part.isdigit()
+                and 0 <= int(part) <= 255
+                and str(int(part)) == part
+                for part in parts
+            )
+        )
+
+    def _set_block_list(self, block_list):
+        self.block_list = block_list if isinstance(block_list, str) else ""
+
+        self.blocked_usernames = set()
+        self.blocked_ip_addresses = set()
+        self.blocked_ip_prefixes = set()
+
+        for rule in self.block_list.splitlines():
+            rule = rule.strip()
+
+            if not rule:
+                continue
+
+            if self._is_ipv4_address(rule):
+                self.blocked_ip_addresses.add(rule)
+            elif self._is_ipv4_prefix(rule):
+                self.blocked_ip_prefixes.add(rule)
+            else:
+                self.blocked_usernames.add(rule)
+
+
     def disconnect(self):
         print("time:", time.time())
         print(self.client_id, "disconnect")
@@ -387,6 +455,11 @@ class Client:
                 max_players,
                 self._server.add_pending_messages,
             )
+            game.creator_blocked_usernames = self.blocked_usernames.copy()
+            game.creator_blocked_ip_addresses = (
+                self.blocked_ip_addresses.copy()
+            )
+            game.creator_blocked_ip_prefixes = self.blocked_ip_prefixes.copy()
             game.join_game(self)
             self._server.game_id_to_game[game_id] = game
 
@@ -440,6 +513,18 @@ class Client:
                     self._server.game_id_to_game[self.game_id].client_ids,
                 )
 
+    def _on_message_set_block_list(self, block_list):
+        if isinstance(block_list, str) and len(block_list) <= 4096:
+            self._set_block_list(block_list)
+            self._server.add_pending_messages(
+                [
+                    [
+                        enums.CommandsToClient.SetBlockList.value,
+                        self.block_list,
+                    ]
+                ],
+                {self.client_id},
+            )
 
 class GameBoard:
     def __init__(self, game, board=None):
@@ -1483,6 +1568,9 @@ class Game:
         self.num_players = 0
         self.client_ids = set()
         self.watcher_client_ids = set()
+        self.creator_blocked_usernames = set()
+        self.creator_blocked_ip_addresses = set()
+        self.creator_blocked_ip_prefixes = set()
 
         self.game_board = GameBoard(self)
         self.score_sheet = ScoreSheet(self)
@@ -1504,7 +1592,35 @@ class Game:
 
         self.set_state(self.state, self.mode, self.max_players)
 
+    def is_client_blocked(self, client):
+        if self.num_players == 0:
+            return False
+
+        if client.username in self.creator_blocked_usernames:
+            return True
+
+        if client.ip_address in self.creator_blocked_ip_addresses:
+            return True
+
+        for prefix in self.creator_blocked_ip_prefixes:
+            if client.ip_address.startswith(prefix):
+                return True
+
+        return False
+
     def join_game(self, client):
+        if self.is_client_blocked(client):
+            self.add_pending_messages(
+                [
+                    [
+                        enums.CommandsToClient.JoinGameBlocked.value,
+                        self.game_id,
+                    ]
+                ],
+                {client.client_id},
+            )
+            return
+
         if (
             self.state == enums.GameStates.Starting.value
             and not self.score_sheet.is_username_in_game(client.username)


### PR DESCRIPTION
This change adds a persistent player block list option for all Acquire players.  Any bad actors in a game creators blocklist will be unable to join games the player creates.   

Allows blocking using:
- Block by exact username
- Block by exact IP address
- Block by IP prefix (e.g. 51.68.244. will block all IP's matching 51.68.244.*)
- Block list is stored persistently in the creators account
- New responsive UI in the Options page for managing blocked players
- Blocks are implemented both client and server side, to prevent scripted work-arounds

This is intended to allow individual players to temporarily or permanently block unwanted players, and players joining from abusive hosts from their games.

Blocked players will see all games in the lobby, but the join button of any blocked game will not function when clicked, and the server will not accept join commands for the games they are blocked from.

<img width="1661" height="550" alt="Block List GUI option" src="https://github.com/user-attachments/assets/ef4655bf-df5b-404c-9298-31215d31ed61" />

<img width="1661" height="550" alt="Blocked Player Perspective" src="https://github.com/user-attachments/assets/472e9179-751f-422e-ab3c-713182844982" />

<img width="1661" height="550" alt="Only affects the creators hosted games" src="https://github.com/user-attachments/assets/051aa40a-1b7d-44a5-bcb2-117b8ea5e99f" />